### PR TITLE
Implement methods to increment/read the metadata version

### DIFF
--- a/server/metadata/meta_version.go
+++ b/server/metadata/meta_version.go
@@ -1,0 +1,30 @@
+package metadata
+
+import (
+	"context"
+	"github.com/tigrisdata/tigrisdb/server/transaction"
+)
+
+var (
+	// VersionKey is the metadata version key whose value is returned to the clients in the transaction
+	VersionKey = []byte{0xff, '/', 'm', 'e', 't', 'a', 'd', 'a', 't', 'a', 'V', 'e', 'r', 's', 'i', 'o', 'n'}
+	// VersionValue is the value set when calling setVersionstampedValue, any value other than this is rejected.
+	VersionValue = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+)
+
+type Version []byte
+
+// MetaVersion is used to maintain a version for each schema change. Using this we can implement transactional DDL APIs.
+// This will also be used to provide a strongly consistent Cache lookup on the schemas i.e. anytime version changes we
+// know that a DDL operation is performed which means we can invalidate the cache and reload from the disk.
+type MetaVersion struct{}
+
+// Increment is used to increment the metadata version
+func (m *MetaVersion) Increment(ctx context.Context, tx transaction.Tx) error {
+	return tx.SetVersionstampedValue(ctx, VersionKey, VersionValue)
+}
+
+// Read reads the latest metadata version
+func (m *MetaVersion) Read(ctx context.Context, tx transaction.Tx) (Version, error) {
+	return tx.Get(ctx, VersionKey)
+}

--- a/server/metadata/meta_version_test.go
+++ b/server/metadata/meta_version_test.go
@@ -1,0 +1,60 @@
+package metadata
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigrisdb/server/config"
+	"github.com/tigrisdata/tigrisdb/server/transaction"
+	"github.com/tigrisdata/tigrisdb/store/kv"
+	"testing"
+)
+
+func TestMetaVersion(t *testing.T) {
+	fdbCfg, err := config.GetTestFDBConfig("../../..")
+	require.NoError(t, err)
+
+	kv, err := kv.NewFoundationDB(fdbCfg)
+	require.NoError(t, err)
+
+	t.Run("read versions", func(t *testing.T) {
+		m := &MetaVersion{}
+		ctx := context.TODO()
+		tm := transaction.NewManager(kv)
+		tx, err := tm.StartTxWithoutTracking(ctx)
+		require.NoError(t, err)
+
+		first, err := m.Read(ctx, tx)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+
+		tx, err = tm.StartTxWithoutTracking(ctx)
+		require.NoError(t, err)
+
+		second, err := m.Read(ctx, tx)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+		require.Equal(t, first, second)
+	})
+	t.Run("bump and read", func(t *testing.T) {
+		m := &MetaVersion{}
+		ctx := context.TODO()
+		tm := transaction.NewManager(kv)
+		tx, err := tm.StartTxWithoutTracking(ctx)
+		require.NoError(t, err)
+		first, err := m.Read(ctx, tx)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+
+		tx, err = tm.StartTxWithoutTracking(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.Increment(ctx, tx))
+		require.NoError(t, tx.Commit(ctx))
+
+		tx, err = tm.StartTxWithoutTracking(ctx)
+		require.NoError(t, err)
+		second, err := m.Read(ctx, tx)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+		require.NotEqual(t, first, second)
+	})
+}

--- a/server/transaction/manager.go
+++ b/server/transaction/manager.go
@@ -45,6 +45,8 @@ type Tx interface {
 	Read(ctx context.Context, key keys.Key) (kv.Iterator, error)
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
+	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
+	Get(ctx context.Context, key []byte) ([]byte, error)
 }
 
 // Manager is used to track all the sessions and provide all the functionality related to transactions. Once created
@@ -233,4 +235,12 @@ func (b *baseTx) Delete(ctx context.Context, key keys.Key) error {
 
 func (b *baseTx) Read(ctx context.Context, key keys.Key) (kv.Iterator, error) {
 	return b.session.read(ctx, key)
+}
+
+func (b *baseTx) SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error {
+	return b.session.setVersionstampedValue(ctx, key, value)
+}
+
+func (b *baseTx) Get(ctx context.Context, key []byte) ([]byte, error) {
+	return b.session.get(ctx, key)
 }

--- a/server/transaction/session.go
+++ b/server/transaction/session.go
@@ -161,6 +161,28 @@ func (s *session) read(ctx context.Context, key keys.Key) (kv.Iterator, error) {
 	return s.kTx.Read(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...))
 }
 
+func (s *session) setVersionstampedValue(ctx context.Context, key []byte, value []byte) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return nil
+	}
+
+	return s.kTx.SetVersionstampedValue(ctx, key, value)
+}
+
+func (s *session) get(ctx context.Context, key []byte) ([]byte, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return nil, err
+	}
+
+	return s.kTx.Get(ctx, key)
+}
+
 func (s *session) commit(ctx context.Context) error {
 	s.Lock()
 	defer s.Unlock()

--- a/store/kv/kv.go
+++ b/store/kv/kv.go
@@ -34,6 +34,8 @@ type crud interface {
 	ReadRange(ctx context.Context, table string, lkey Key, rkey Key) (Iterator, error)
 	Update(ctx context.Context, table string, key Key, apply func([]byte) ([]byte, error)) error
 	UpdateRange(ctx context.Context, table string, lKey Key, rKey Key, apply func([]byte) ([]byte, error)) error
+	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
+	Get(ctx context.Context, key []byte) ([]byte, error)
 }
 
 type Tx interface {


### PR DESCRIPTION
The idea is to track the schema change using metadata version key. Using this we can implement transactional DDL APIs.
This will also be used to provide a strongly consistent Cache lookup on the schemas i.e. anytime version changes we
know that a DDL operation is performed which means we can invalidate the cache and reload from the disk.