### PR TITLE
[k8s] A second service is needed to be able to route the HTTP and GRPC traffic

### DIFF
--- a/deployment/manifests/base/service_grpc.yaml
+++ b/deployment/manifests/base/service_grpc.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tigrisdb-server
+    app.kubernetes.io/part-of: tigrisdb
+    app.kubernetes.io/component: server-grpc
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+  name: tigrisdb-server-grpc
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      name: http
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: tigrisdb-server


### PR DESCRIPTION
A second service is needed to be able to route the HTTP and GRPC traffic correctly from the ALB based on the headers