### PR TITLE
Revert "[k8s] The grpc service has to be defined as a headless service"

### DIFF
--- a/deployment/manifests/base/service_grpc.yaml
+++ b/deployment/manifests/base/service_grpc.yaml
@@ -24,7 +24,6 @@ metadata:
   name: tigrisdb-server-grpc
 spec:
   type: NodePort
-  clusterIP: None # bypass kube-proxy as the default k8s load balancing does not work well with grpc
   ports:
     - port: 80
       name: http


### PR DESCRIPTION
Reverts tigrisdata/tigrisdb#160