### PR TITLE
fix!: Updated schema to use title attribute for schema name

### DIFF
--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCollection_SchemaValidate(t *testing.T) {
 	reqSchema := []byte(`{
-		"name": "t1",
+		"title": "t1",
 		"properties": {
 			"id": {
 				"type": "integer"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -73,7 +73,7 @@ var (
 )
 
 type JSONSchema struct {
-	Name        string              `json:"name,omitempty"`
+	Name        string              `json:"title,omitempty"`
 	Description string              `json:"description,omitempty"`
 	Properties  jsoniter.RawMessage `json:"properties,omitempty"`
 	PrimaryKeys []string            `json:"primary_key,omitempty"`

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCreateCollectionFromSchema(t *testing.T) {
 	t.Run("test_create_success", func(t *testing.T) {
-		reqSchema := []byte(`{"name":"t1", "description":"This document records the details of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
+		reqSchema := []byte(`{"title":"t1", "description":"This document records the details of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
 		schF, err := Build("t1", reqSchema)
 		require.NoError(t, err)
 		c := NewDefaultCollection("t1", 1, schF.Fields, schF.Indexes, schF.Schema)
@@ -34,13 +34,13 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		require.Equal(t, c.Indexes.PrimaryKey.Fields[1].FieldName, "order_id")
 	})
 	t.Run("test_create_failure", func(t *testing.T) {
-		reqSchema := []byte(`{"name":"Record of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
+		reqSchema := []byte(`{"title":"Record of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
 		_, err := Build("t1", reqSchema)
 		require.Equal(t, "collection name is not same as schema name 't1' 'Record of an order'", err.(*api.TigrisDBError).Error())
 	})
 	t.Run("test_supported_types", func(t *testing.T) {
 		schema := []byte(`{
-	"name": "t1",
+	"title": "t1",
 	"properties": {
 		"K1": {
 			"type": "string"
@@ -83,7 +83,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_supported_primary_keys", func(t *testing.T) {
 		schema := []byte(`{
-	"name": "t1",
+	"title": "t1",
 	"properties": {
 		"K1": {
 			"type": "string"
@@ -118,7 +118,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_unsupported_primary_key", func(t *testing.T) {
 		schema := []byte(`{
-		"name": "t1",
+		"title": "t1",
 		"properties": {
 			"K1": {
 				"type": "number"
@@ -134,7 +134,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_complex_types", func(t *testing.T) {
 		schema := []byte(`{
-	"name": "t1",
+	"title": "t1",
 	"properties": {
 		"id": {
 			"type": "integer"
@@ -209,7 +209,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_array_missing_items_error", func(t *testing.T) {
 		schema := []byte(`{
-	"name": "t1",
+	"title": "t1",
 	"properties": {
 		"id": {
 			"type": "integer"
@@ -225,7 +225,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_object_missing_properties_error", func(t *testing.T) {
 		schema := []byte(`{
-	"name": "t1",
+	"title": "t1",
 	"properties": {
 		"id": {
 			"type": "integer"

--- a/server/metadata/encoding/schema_test.go
+++ b/server/metadata/encoding/schema_test.go
@@ -69,7 +69,7 @@ func TestSchemaSubspace(t *testing.T) {
 		_ = kv.DropTable(ctx, SchemaSubspaceKey)
 
 		schema := []byte(`{
-		"name": "collection1",
+		"title": "collection1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {
@@ -111,7 +111,7 @@ func TestSchemaSubspace(t *testing.T) {
 		_ = kv.DropTable(ctx, SchemaSubspaceKey)
 
 		schema1 := []byte(`{
-		"name": "collection1",
+		"title": "collection1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {
@@ -128,7 +128,7 @@ func TestSchemaSubspace(t *testing.T) {
 		"primary_key": ["K1", "K2"]
 	}`)
 		schema2 := []byte(`{
-		"name": "collection1",
+		"title": "collection1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {
@@ -168,7 +168,7 @@ func TestSchemaSubspace(t *testing.T) {
 		_ = kv.DropTable(ctx, SchemaSubspaceKey)
 
 		schema1 := []byte(`{
-		"name": "collection1",
+		"title": "collection1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {
@@ -185,7 +185,7 @@ func TestSchemaSubspace(t *testing.T) {
 		"primary_key": ["K1", "K2"]
 	}`)
 		schema2 := []byte(`{
-		"name": "collection1",
+		"title": "collection1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -194,7 +194,7 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 		require.Equal(t, "db2", db2.name)
 
 		jsSchema := []byte(`{
-        "name": "test_collection",
+        "title": "test_collection",
 		"properties": {
 			"K1": {
 				"type": "string"
@@ -255,7 +255,7 @@ func TestTenantManager_DropCollection(t *testing.T) {
 		require.Equal(t, "db2", db2.name)
 
 		jsSchema := []byte(`{
-		"name": "test_collection",
+		"title": "test_collection",
 		"properties": {
 			"K1": {
 				"type": "string"

--- a/test/v1/client/client_test.go
+++ b/test/v1/client/client_test.go
@@ -78,7 +78,7 @@ func testClientBinary(t *testing.T, c driver.Driver) {
 	_ = c.DropCollection(ctx, "db1", "c1", &driver.CollectionOptions{})
 
 	schema := `{
-		"name": "c1",
+		"title": "c1",
 		"properties": {
 			"K1": {
 				"type": "string",
@@ -154,7 +154,7 @@ func testClient(t *testing.T, c driver.Driver) {
 	_ = c.DropCollection(ctx, "db1", "c1", &driver.CollectionOptions{})
 
 	schema := `{
-		"name": "c1",
+		"title": "c1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {
@@ -216,7 +216,7 @@ func testTxClient(t *testing.T, c driver.Driver) {
 	_ = c.DropCollection(ctx, "db1", "c1", &driver.CollectionOptions{})
 
 	schema := `{
-		"name": "c1",
+		"title": "c1",
 		"description": "this schema is for client integration tests",
 		"properties": {
 			"K1": {

--- a/test/v1/server/collection_test.go
+++ b/test/v1/server/collection_test.go
@@ -28,7 +28,7 @@ import (
 
 /**
 {
-	"name": "test_collection",
+	"title": "test_collection",
 	"description": "this schema is for integration tests",
 	"properties": {
 		"pkey_int": {
@@ -66,7 +66,7 @@ import (
 */
 var testCreateSchema = map[string]interface{}{
 	"schema": map[string]interface{}{
-		"name":        "test_collection",
+		"title":       "test_collection",
 		"description": "this schema is for integration tests",
 		"properties": map[string]interface{}{
 			"pkey_int": map[string]interface{}{

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -241,7 +241,7 @@ func (s *DocumentSuite) TestInsert_SupportedPrimaryKeys() {
 		{
 			schema: map[string]interface{}{
 				"schema": map[string]interface{}{
-					"name": collectionName,
+					"title": collectionName,
 					"properties": map[string]interface{}{
 						"int_value": map[string]interface{}{
 							"type": "integer",
@@ -266,7 +266,7 @@ func (s *DocumentSuite) TestInsert_SupportedPrimaryKeys() {
 		}, {
 			schema: map[string]interface{}{
 				"schema": map[string]interface{}{
-					"name": collectionName,
+					"title": collectionName,
 					"properties": map[string]interface{}{
 						"int_value": map[string]interface{}{
 							"type": "integer",
@@ -291,7 +291,7 @@ func (s *DocumentSuite) TestInsert_SupportedPrimaryKeys() {
 		}, {
 			schema: map[string]interface{}{
 				"schema": map[string]interface{}{
-					"name": collectionName,
+					"title": collectionName,
 					"properties": map[string]interface{}{
 						"int_value": map[string]interface{}{
 							"type": "integer",
@@ -316,7 +316,7 @@ func (s *DocumentSuite) TestInsert_SupportedPrimaryKeys() {
 		}, {
 			schema: map[string]interface{}{
 				"schema": map[string]interface{}{
-					"name": collectionName,
+					"title": collectionName,
 					"properties": map[string]interface{}{
 						"int_value": map[string]interface{}{
 							"type": "integer",
@@ -340,7 +340,7 @@ func (s *DocumentSuite) TestInsert_SupportedPrimaryKeys() {
 		}, {
 			schema: map[string]interface{}{
 				"schema": map[string]interface{}{
-					"name": collectionName,
+					"title": collectionName,
 					"properties": map[string]interface{}{
 						"int_value": map[string]interface{}{
 							"type": "integer",


### PR DESCRIPTION
To better comply with JSON schema standard. Updating TigrisDB schema to read the schema name from `title` attribute. (It was `name` before)